### PR TITLE
Prettify chatlogger script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2015-02-09
+----------
+
+- Code cleanup for chat logger script.
+- Use hash tables for command execution instead of `if-else` statement blocks.
+- Fix the conversion of `&amp;` etc. entities before writing to log file.
+
 2014-11-30
 ----------
 

--- a/chatlogger.lua
+++ b/chatlogger.lua
@@ -56,22 +56,20 @@ end
 RegConnected, OpConnected = UserConnected, UserConnected
 
 function History( iNumLines )
-	local iStartIndex = ( #tChatHistory - iNumLines ) + 1
-	if #tChatHistory < iNumLines then
+	local iStartIndex, iTotalLines = ( #tChatHistory - iNumLines ) + 1, #tChatHistory
+	if iTotalLines < iNumLines then
 		iStartIndex = 1
 	end
-	if iStartIndex > #tChatHistory then
-		iStartIndex = #tChatHistory
+	if iStartIndex > iTotalLines then
+		iStartIndex = iTotalLines
 	end
-	return table.concat( tChatHistory, "\n\t", iStartIndex, #tChatHistory )
+	return table.concat( tChatHistory, "\n\t", iStartIndex, iTotalLines )
 end
 
 function LogMessage( sLine )
 	local sTime = os.date( tConfig.sTimeFormat )
 	local sChatLine, sFileName = sTime..sLine, tConfig.sLogsPath..os.date( "%Y/%m/%d_%m_%Y" )..".txt"
-	sChatLine = sChatLine:gsub( "&#(%d+);", function(x)
-			return string.char( tonumber(x) )
-		end ):gsub( "[\n\r]+", "\n\t" ):gsub(  "&amp;", "&" )
+	sChatLine = sChatLine:gsub( "&#(%d+);", string.char ):gsub( "[\n\r]+", "\n\t" ):gsub( "&amp;", "&" )
 	local fWrite = io.open( sFileName, "a" )
 	fWrite:write( sChatLine.."\n" )
 	fWrite:flush()

--- a/chatlogger.lua
+++ b/chatlogger.lua
@@ -24,7 +24,7 @@ function ChatArrival( tUser, sMessage )
 	local sChatLine = sTime..sMessage:sub( 1, -2 )
 	if not( sCmd and tConfig.sProfiles:find(tUser.iProfile) ) then
 		table.insert( tChatHistory, sChatLine )
-		if tChatHistory[tConfig.iMaxLines + 1] then
+		if tChatHistory[ tConfig.iMaxLines + 1 ] then
 			table.remove( tChatHistory, 1 )
 		end
 	end
@@ -55,9 +55,9 @@ RegConnected, OpConnected = UserConnected, UserConnected
 
 function ExecuteCommand( sCmd, sData, tUser, bIsPM )
 	if sCmd == "history" then
-		local sSendValue, sData = "<%s> \n\r\t\tChat history bot for HiT Hi FiT Hai\n\tShowing the mainchat history for past %d messages\n", tonumber(sData)
-		if (not sData) or sData > 100 or sData < 0 then sData = 15 end
-		sSendValue = sSendValue:format( tConfig.sBotName, sData )..History( sData )
+		local sSendValue, iLimit = "<%s> \n\r\t\tChat history bot for HiT Hi FiT Hai\n\tShowing the mainchat history for past %d messages\n\t", tonumber(sData)
+		if (not iLimit) or iLimit > tConfig.iMaxLines or iLimit < 0 then iLimit = 15 end
+		sSendValue = sSendValue:format( tConfig.sBotName, iLimit )..History( iLimit )
 		if bIsPM then
 			Core.SendPmToUser( tUser, tConfig.sBotName, sSendValue )
 		else
@@ -92,12 +92,8 @@ function History( iNumLines )
 	local iStartIndex = ( #tChatHistory - iNumLines ) + 1
 	if #tChatHistory < iNumLines then
 		iStartIndex = 1
-	else
-		iStartIndex = #tChatHistory - iNumLines + 1
 	end
-	if iStartIndex == 0 then
-		iStartIndex = 1
-	elseif iStartIndex > #tChatHistory then
+	if iStartIndex > #tChatHistory then
 		iStartIndex = #tChatHistory
 	end
 	return table.concat( tChatHistory, "\n\t", iStartIndex, #tChatHistory )

--- a/chatlogger.lua
+++ b/chatlogger.lua
@@ -12,15 +12,16 @@ function OnStartup()
 		sBotName = SetMan.GetString( 21 ) or "PtokaX",
 		sProfiles = "012",		-- No history for commands from users with profiles
 		sLogsPath = "/www/ChatLogs/",
+		sTimeFormat = "[%I:%M:%S %p] ",
 		iMaxLines = 100,
 	}, { "Hi!" }
 end
 
 function ChatArrival( tUser, sMessage )
 	LogMessage( sMessage:sub(1, -2) )
-	local sCmd, sData = sMessage:match( "%b<> [-+*/?!#](%w+)%s?(.*)|" )
-	local sTime = os.date( "%I:%M:%S %p" )
-	local sChatLine = "["..sTime.."] "..sMessage:sub( 1, -2 )
+	local sCmd, sData = sMessage:match "%b<> [-+*/?!#](%w+)%s?(.*)|"
+	local sTime = os.date( tConfig.sTimeFormat )
+	local sChatLine = sTime..sMessage:sub( 1, -2 )
 	if not( sCmd and tConfig.sProfiles:find(tUser.iProfile) ) then
 		table.insert( tChatHistory, sChatLine )
 		if tChatHistory[tConfig.iMaxLines + 1] then
@@ -34,9 +35,9 @@ function ChatArrival( tUser, sMessage )
 end
 
 function ToArrival( tUser, sMessage )
-	local sTo, sFrom = sMessage:match("$To: (%S+) From: (%S+)")
+	local sTo, sFrom = sMessage:match "$To: (%S+) From: (%S+)"
 	if sTo ~= tConfig.sBotName then return false end
-	local sCmd, sData = sMessage:match("%b$$%b<> [-+*/?!#](%w+)%s?(.*)|")
+	local sCmd, sData = sMessage:match "%b$$%b<> [-+*/?!#](%w+)%s?(.*)|"
 	if sCmd then
 		return ExecuteCommand( sCmd:lower(), sData, tUser, true )
 	end
@@ -103,8 +104,8 @@ function History( iNumLines )
 end
 
 function LogMessage( sLine )
-	local sTime = os.date( "%I:%M:%S %p" )
-	local sChatLine, sFileName = "["..sTime.."] "..sLine, tConfig.sLogsPath..os.date( "%Y/%m/%d_%m_%Y" )..".txt"
+	local sTime = os.date( tConfig.sTimeFormat )
+	local sChatLine, sFileName = sTime..sLine, tConfig.sLogsPath..os.date( "%Y/%m/%d_%m_%Y" )..".txt"
 	sChatLine = sChatLine:gsub( "&#124;", "|" ):gsub( "&#36;", "$" ):gsub( "[\n\r]+", "\n\t" )
 	local fWrite = io.open( sFileName, "a" )
 	fWrite:write( sChatLine.."\n" )

--- a/chatlogger.lua
+++ b/chatlogger.lua
@@ -15,6 +15,9 @@ function OnStartup()
 		sTimeFormat = "[%I:%M:%S %p] ",
 		iMaxLines = 100,
 	}, { "Hi!" }
+	for Index, Callback in pairs( ExecuteCommand ) do
+		ExecuteCommand[Index] = Callback()
+	end
 end
 
 function ChatArrival( tUser, sMessage )
@@ -28,8 +31,9 @@ function ChatArrival( tUser, sMessage )
 			table.remove( tChatHistory, 1 )
 		end
 	end
-	if sCmd then
-		return ExecuteCommand( sCmd:lower(), sData, tUser )
+	sCmd = sCmd:lower()
+	if ExecuteCommand[sCmd] then
+		return ExecuteCommand[sCmd]( tUser, sData, false )
 	end
 	return false
 end
@@ -38,8 +42,9 @@ function ToArrival( tUser, sMessage )
 	local sTo, sFrom = sMessage:match "$To: (%S+) From: (%S+)"
 	if sTo ~= tConfig.sBotName then return false end
 	local sCmd, sData = sMessage:match "%b$$%b<> [-+*/?!#](%w+)%s?(.*)|"
-	if sCmd then
-		return ExecuteCommand( sCmd:lower(), sData, tUser, true )
+	sCmd = sCmd:lower()
+	if ExecuteCommand[sCmd] then
+		return ExecuteCommand[sCmd]( tUser, sData, true )
 	end
 	return false
 end


### PR DESCRIPTION
 * [x] Fix redundant computation of `iStartIndex`
 * [x] Pass constant string parameters without parenthesis for functions
 * [x] Use a hash table for executing commands
 * [x] Do not assign memory to `local` variables in every function call.
 * [ ] Test the script on hub.